### PR TITLE
Split of StakingWallet in two different contracts (CST & RWalk)

### DIFF
--- a/contracts/StakingWalletRWalk.sol
+++ b/contracts/StakingWalletRWalk.sol
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity 0.8.19;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { CosmicGame } from "./CosmicGame.sol";
+import { CosmicSignature } from "./CosmicSignature.sol";
+import { CosmicGameConstants } from "./Constants.sol";
+import { RandomWalkNFT } from "./RandomWalkNFT.sol";
+
+contract StakingWalletRWalk is Ownable {
+	struct StakeAction {
+		uint256 tokenId;
+		address owner;
+		uint256 stakeTime;
+		uint256 unstakeTime;
+		uint256 unstakeEligibleTime;
+		mapping(uint256 => bool) depositClaimed;
+	}
+
+	struct ETHDeposit {
+		uint256 depositTime;
+		uint256 depositAmount;
+		uint256 numStaked;
+	}
+
+	mapping(uint256 => StakeAction) public stakeActions;
+	uint256 public numStakeActions;
+
+	// Variables to manage uniquneness of tokens and pick random winner
+	uint256[] public stakedTokens;
+	mapping(uint256 => uint256) public tokenIndices; // tokenId -> tokenIndex
+	mapping(uint256 => int256) public lastActionIds; // tokenId -> actionId
+
+	mapping(uint256 => ETHDeposit) public ETHDeposits;
+	uint256 public numETHDeposits;
+
+	uint256 public numStakedNFTs;
+
+	uint256 public minStakePeriod = CosmicGameConstants.DEFAULT_MIN_STAKE_PERIOD;
+
+	RandomWalkNFT public randomWalk;
+	CosmicGame public game;
+
+	event StakeActionEvent(
+		uint256 indexed actionId,
+		uint256 indexed tokenId,
+		uint256 totalNFTs,
+		uint256 unstakeTime,
+		address indexed staker
+	);
+	event UnstakeActionEvent(
+		uint256 indexed actionId,
+		uint256 indexed tokenId,
+		uint256 totalNFTs,
+		address indexed staker
+	);
+	event MinStakePeriodChanged(uint256 newPeriod);
+
+	constructor(RandomWalkNFT rwalk_, CosmicGame game_) {
+		require(address(rwalk_) != address(0), "Zero-address was given for the RandomWalk token.");
+		require(address(game_) != address(0), "Zero-address was given for the game.");
+		randomWalk = rwalk_;
+		game = game_;
+	}
+
+	function stake(uint256 _tokenId) public {
+		randomWalk.transferFrom(msg.sender, address(this), _tokenId);
+		_insertToken(_tokenId, numStakeActions);
+		stakeActions[numStakeActions].tokenId = _tokenId;
+		stakeActions[numStakeActions].owner = msg.sender;
+		stakeActions[numStakeActions].stakeTime = block.timestamp;
+		uint256 unstakeTime = block.timestamp + minStakePeriod;
+		require(unstakeTime > block.timestamp, "Unstake time should be bigger than block timestamp");
+		stakeActions[numStakeActions].unstakeEligibleTime = unstakeTime;
+		numStakeActions += 1;
+		numStakedNFTs += 1;
+		emit StakeActionEvent(
+			numStakeActions - 1,
+			_tokenId,
+			numStakedNFTs,
+			stakeActions[numStakeActions - 1].unstakeEligibleTime,
+			msg.sender
+		);
+	}
+
+	function stakeMany(uint256[] memory ids) external {
+		for (uint256 i = 0; i < ids.length; i++) {
+			stake(ids[i]);
+		}
+	}
+
+	function unstake(uint256 stakeActionId) public {
+		require(stakeActions[stakeActionId].unstakeTime == 0, "Token has already been unstaked.");
+		require(stakeActions[stakeActionId].owner == msg.sender, "Only the owner can unstake.");
+		require(stakeActions[stakeActionId].unstakeEligibleTime < block.timestamp, "Not allowed to unstake yet.");
+		uint256 tokenId = stakeActions[stakeActionId].tokenId;
+		_removeToken(tokenId);
+		randomWalk.transferFrom(address(this), msg.sender, stakeActions[stakeActionId].tokenId);
+		stakeActions[stakeActionId].unstakeTime = block.timestamp;
+		numStakedNFTs -= 1;
+		emit UnstakeActionEvent(stakeActionId, tokenId, numStakedNFTs, msg.sender);
+	}
+
+	function unstakeMany(uint256[] memory ids) external {
+		for (uint256 i = 0; i < ids.length; i++) {
+			unstake(ids[i]);
+		}
+	}
+
+	function setMinStakePeriod(uint256 newStakePeriod) external onlyOwner {
+		minStakePeriod = newStakePeriod;
+		emit MinStakePeriodChanged(newStakePeriod);
+	}
+
+	function isTokenStaked(uint256 tokenId) public view returns (bool) {
+		return tokenIndices[tokenId] != 0;
+	}
+
+	function numTokensStaked() public view returns (uint256) {
+		return stakedTokens.length;
+	}
+
+	function tokenByIndex(uint256 tokenIndex) public view returns (uint256) {
+		require(tokenIndex > 0, "Zero was given, token indices start from 1");
+		return tokenIndices[tokenIndex];
+	}
+
+	function lastActionIdByTokenId(uint256 tokenId) public view returns (int256) {
+		uint256 tokenIndex = tokenIndices[tokenId];
+		if (tokenIndex == 0) {
+			return -2;
+		}
+		int256 lastActionId = lastActionIds[tokenId];
+		return lastActionId; // will return -1 if token is not staked, > -1 if there is an ID
+	}
+
+	function stakerByTokenId(uint256 tokenId) public view returns (address) {
+		int256 actionId;
+		actionId = lastActionIdByTokenId(tokenId);
+		if (actionId < 0) {
+			return address(0);
+		}
+		address staker = stakeActions[uint256(actionId)].owner;
+		return staker;
+	}
+
+	function pickRandomStaker(bytes32 entropy) public view returns (address) {
+		require(stakedTokens.length > 0, "There are no RandomWalk tokens staked.");
+		uint256 luckyTokenId = stakedTokens[uint256(entropy) % stakedTokens.length];
+		int256 actionId = lastActionIds[luckyTokenId];
+		return stakeActions[uint256(actionId)].owner;
+	}
+
+	function _insertToken(uint256 tokenId, uint256 actionId) internal {
+		require(!isTokenStaked(tokenId), "Token already in the list.");
+		stakedTokens.push(tokenId);
+		tokenIndices[tokenId] = stakedTokens.length;
+		lastActionIds[tokenId] = int256(actionId);
+	}
+
+	function _removeToken(uint256 tokenId) internal {
+		require(isTokenStaked(tokenId), "Token is not in the list.");
+		uint256 index = tokenIndices[tokenId];
+		uint256 lastTokenId = stakedTokens[stakedTokens.length - 1];
+		stakedTokens[index - 1] = lastTokenId;
+		tokenIndices[lastTokenId] = index;
+		delete tokenIndices[tokenId];
+		stakedTokens.pop();
+		lastActionIds[tokenId] = -1;
+	}
+}

--- a/contracts/tests/BidderContract.sol
+++ b/contracts/tests/BidderContract.sol
@@ -25,7 +25,7 @@ contract BidderContract is IERC721Receiver {
 		creator = msg.sender;
 	}
 	receive() external payable {
-		require(!blockDeposits,"I am not accepting deposits");
+		require(!blockDeposits, "I am not accepting deposits");
 	}
 	function doBid() external payable {
 		uint256 price = cosmicGame.getBidPrice();
@@ -42,7 +42,7 @@ contract BidderContract is IERC721Receiver {
 		defaultParams.randomWalkNFTId = -1;
 		bytes memory param_data;
 		param_data = abi.encode(defaultParams);
-		cosmicGame.bid{ value: msg.value}(param_data);
+		cosmicGame.bid{ value: msg.value }(param_data);
 	}
 	function doBidRWalk(int256 tokenId) external payable {
 		uint256 price = cosmicGame.getBidPrice();
@@ -56,13 +56,13 @@ contract BidderContract is IERC721Receiver {
 	function doBidRWalk2(int256 tokenId) external payable {
 		RandomWalkNFT rwalk = cosmicGame.randomWalk();
 		rwalk.setApprovalForAll(address(cosmicGame), true);
-		rwalk.transferFrom( msg.sender,address(this), uint256(tokenId));
+		rwalk.transferFrom(msg.sender, address(this), uint256(tokenId));
 		BusinessLogic.BidParams memory params;
 		params.message = "contract bid rwalk";
 		params.randomWalkNFTId = tokenId;
 		bytes memory param_data;
 		param_data = abi.encode(params);
-		cosmicGame.bid{ value: msg.value}(param_data);
+		cosmicGame.bid{ value: msg.value }(param_data);
 	}
 	function doBidAndDonate(address nftAddress, uint256 tokenId) external payable {
 		IERC721(nftAddress).setApprovalForAll(address(cosmicGame), true);

--- a/contracts/tests/Delegate.sol
+++ b/contracts/tests/Delegate.sol
@@ -6,7 +6,8 @@ import { CosmicGame } from "../CosmicGame.sol";
 import { CosmicToken } from "../CosmicToken.sol";
 import { CosmicSignature } from "../CosmicSignature.sol";
 import { RaffleWallet } from "../RaffleWallet.sol";
-import { StakingWallet } from "../StakingWallet.sol";
+import { StakingWalletCST } from "../StakingWalletCST.sol";
+import { StakingWalletRWalk } from "../StakingWalletRWalk.sol";
 import { MarketingWallet } from "../MarketingWallet.sol";
 import { RandomWalkNFT } from "../RandomWalkNFT.sol";
 import { BusinessLogic } from "../BusinessLogic.sol";
@@ -104,13 +105,13 @@ contract BLTest is BusinessLogic {
 		stakingPercentage = DEFAULT_VALUE;
 	}
 	function f29() external {
-		numRaffleWinnersPerRound = DEFAULT_VALUE;
+		numRaffleETHWinnersBidding = DEFAULT_VALUE;
 	}
 	function f30() external {
-		numRaffleNFTWinnersPerRound = DEFAULT_VALUE;
+		numRaffleNFTWinnersBidding= DEFAULT_VALUE;
 	}
 	function f31() external {
-		numHolderNFTWinnersPerRound = DEFAULT_VALUE;
+		numRaffleNFTWinnersStakingCST = DEFAULT_VALUE;
 	}
 	function f32() external {
 		winners[DEFAULT_INDEX] = DEFAULT_ADDRESS;
@@ -122,7 +123,7 @@ contract BLTest is BusinessLogic {
 		raffleWallet = RaffleWallet(DEFAULT_ADDRESS);
 	}
 	function f35() external {
-		stakingWallet = StakingWallet(DEFAULT_ADDRESS);
+		stakingWalletCST = StakingWalletCST(DEFAULT_ADDRESS);
 	}
 	function f36() external {
 		donatedNFTs[DEFAULT_INDEX].round = DEFAULT_VALUE;
@@ -141,6 +142,12 @@ contract BLTest is BusinessLogic {
 	}
 	function f41() external {
 		systemMode = DEFAULT_VALUE;
+	}
+	function f42() external {
+		stakingWalletRWalk = StakingWalletRWalk(DEFAULT_ADDRESS);
+	}
+	function f43() external {
+		numRaffleNFTWinnersStakingRWalk = DEFAULT_VALUE;
 	}
 }
 
@@ -311,6 +318,14 @@ contract CGTest is CosmicGame {
 	}
 	function f41() external {
 		(bool success, ) = address(bLogic).delegatecall(abi.encodeWithSelector(BLTest.f41.selector));
+		require(success, "Delegate call execution failed.");
+	}
+	function f42() external {
+		(bool success, ) = address(bLogic).delegatecall(abi.encodeWithSelector(BLTest.f42.selector));
+		require(success, "Delegate call execution failed.");
+	}
+	function f43() external {
+		(bool success, ) = address(bLogic).delegatecall(abi.encodeWithSelector(BLTest.f43.selector));
 		require(success, "Delegate call execution failed.");
 	}
 }

--- a/contracts/tests/TestingContracts.sol
+++ b/contracts/tests/TestingContracts.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
-import { StakingWallet } from "../StakingWallet.sol";
+import { StakingWalletCST } from "../StakingWalletCST.sol";
+import { StakingWalletRWalk } from "../StakingWalletRWalk.sol";
 import { RaffleWallet } from "../RaffleWallet.sol";
 import { CosmicGame } from "../CosmicGame.sol";
 import { CosmicSignature } from "../CosmicSignature.sol";
@@ -12,10 +13,10 @@ import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 contract BrokenToken {
 	// used to test revert() statements in token transfers in claimPrize() function
 	uint256 counter;
-    function mint(address , uint256 round) public {
+	function mint(address, uint256 round) public {
 		counter = round;
-		require(false,"Test mint() failed");
-    }
+		require(false, "Test mint() failed");
+	}
 	function totalSupply() public pure returns (uint256) {
 		return 1;
 	}
@@ -24,42 +25,42 @@ contract BrokenERC20 {
 	// used to test revert() statements in BusinessLogic contract
 	uint256 counter;
 	function mint(address, uint256) external pure {
-		require(false,"Test mint() (ERC20) failed");
+		require(false, "Test mint() (ERC20) failed");
 	}
 }
 contract BrokenCharity {
 	// used to test revert() statements for charity deposits
 	uint256 counter;
 	receive() external payable {
-		require(false,"Test deposit failed");
-    }
+		require(false, "Test deposit failed");
+	}
 }
 contract BrokenStaker {
 	// used to test revert() statements in StakingWallet
 	bool blockDeposits = false;
-	StakingWallet stakingWallet;
-	constructor(StakingWallet sw_,address nft_) {
-		stakingWallet = sw_;
+	StakingWalletCST stakingWalletCST;
+	constructor(StakingWalletCST sw_, address nft_) {
+		stakingWalletCST = sw_;
 		IERC721(nft_).setApprovalForAll(address(sw_), true);
 	}
 	receive() external payable {
-		require(!blockDeposits,"I am not accepting deposits");
-    }
-	function doStake(uint256 tokenId,bool isRWalk) external {
-		stakingWallet.stake(tokenId,isRWalk);
+		require(!blockDeposits, "I am not accepting deposits");
+	}
+	function doStake(uint256 tokenId) external {
+		stakingWalletCST.stake(tokenId);
 	}
 	function doUnstake(uint256 actionId) external {
-		stakingWallet.unstake(actionId);
+		stakingWalletCST.unstake(actionId);
 	}
-	function doClaimReward(uint256 stakeActionId,uint256 depositId) external {
-		stakingWallet.claimReward(stakeActionId,depositId);
+	function doClaimReward(uint256 stakeActionId, uint256 depositId) external {
+		stakingWalletCST.claimReward(stakeActionId, depositId);
 	}
 	function startBlockingDeposits() external {
 		blockDeposits = true;
-    }
+	}
 }
 contract SelfdestructibleCosmicGame is CosmicGame {
-	// This contract will return all the assets before selfdestruct transaction, 
+	// This contract will return all the assets before selfdestruct transaction,
 	// required for testing on the MainNet (Arbitrum) (prior to launch)
 
 	constructor() CosmicGame() {}
@@ -69,18 +70,18 @@ contract SelfdestructibleCosmicGame is CosmicGame {
 
 		// CosmicSignature tokens
 		uint256 cosmicSupply = nft.totalSupply();
-		for (uint256 i = 0; i < cosmicSupply ; i++) {
+		for (uint256 i = 0; i < cosmicSupply; i++) {
 			address owner = nft.ownerOf(i);
 			if (owner == address(this)) {
 				nft.transferFrom(address(this), this.owner(), i);
 			}
 		}
 		cosmicSupply = token.balanceOf(address(this));
-		token.transfer(this.owner(),cosmicSupply);
+		token.transfer(this.owner(), cosmicSupply);
 		for (uint256 i = 0; i < numDonatedNFTs; i++) {
 			CosmicGameConstants.DonatedNFT memory dnft = donatedNFTs[i];
-			IERC721(dnft.nftAddress).transferFrom(address(this),this.owner(),dnft.tokenId);
-        }
+			IERC721(dnft.nftAddress).transferFrom(address(this), this.owner(), dnft.tokenId);
+		}
 		selfdestruct(payable(this.owner()));
 	}
 }
@@ -89,13 +90,13 @@ contract SpecialCosmicGame is CosmicGame {
 
 	constructor() CosmicGame() {}
 	function setCharityRaw(address addr) external {
-        charity = addr;
-    }
+		charity = addr;
+	}
 	function setRaffleWalletRaw(address addr) external {
 		raffleWallet = RaffleWallet(addr);
 	}
-	function setStakingWalletRaw(address addr) external {
-		stakingWallet = StakingWallet(addr);
+	function setStakingWalletCSTRaw(address addr) external {
+		stakingWalletCST = StakingWalletCST(addr);
 	}
 	function setNftContractRaw(address addr) external {
 		nft = CosmicSignature(addr);
@@ -104,48 +105,33 @@ contract SpecialCosmicGame is CosmicGame {
 		token = CosmicToken(addr);
 	}
 	function setActivationTimeRaw(uint256 newActivationTime) external {
-        activationTime = newActivationTime;
-        lastCSTBidTime = activationTime;
+		activationTime = newActivationTime;
+		lastCSTBidTime = activationTime;
 	}
 }
-contract TestStakingWallet is StakingWallet {
+contract TestStakingWallet is StakingWalletCST {
+	constructor(
+		CosmicSignature nft_,
+		CosmicGame game_,
+		address charity_
+	) StakingWalletCST(nft_, game_, charity_) {}
 
-	constructor(CosmicSignature nft_, RandomWalkNFT rwalk_,CosmicGame game_, address charity_) StakingWallet(nft_,rwalk_, game_, charity_) {}
-	
 	// note: functions must be copied from parent by hand (after every update), since parent have them as 'internal'
-	function insertTokenCST(uint256 tokenId,uint256 actionId) external {
-		require(!isTokenStakedCST(tokenId),"Token already in the list.");
-		stakedTokensCST.push(tokenId);
-		tokenIndicesCST[tokenId] = stakedTokensCST.length;
-		lastActionIdsCST[tokenId] = int256(actionId);
+	function insertToken(uint256 tokenId, uint256 actionId) external {
+		require(!isTokenStaked(tokenId), "Token already in the list.");
+		stakedTokens.push(tokenId);
+		tokenIndices[tokenId] = stakedTokens.length;
+		lastActionIds[tokenId] = int256(actionId);
 	}
 
-	function removeTokenCST(uint256 tokenId) external {
-		require(isTokenStakedCST(tokenId),"Token is not in the list.");
-		uint256 index = tokenIndicesCST[tokenId];
-		uint256 lastTokenId = stakedTokensCST[stakedTokensCST.length - 1];
-		stakedTokensCST[index -1] = lastTokenId;
-		tokenIndicesCST[lastTokenId] = index;
-		delete tokenIndicesCST[tokenId];
-		stakedTokensCST.pop();
-		lastActionIdsCST[tokenId] = -1;
-	}
-
-	function insertTokenRWalk(uint256 tokenId,uint256 actionId) external {
-		require(!isTokenStakedRWalk(tokenId),"Token already in the list.");
-		stakedTokensRWalk.push(tokenId);
-		tokenIndicesRWalk[tokenId] = stakedTokensRWalk.length;
-		lastActionIdsRWalk[tokenId] = int256(actionId);
-	}
-
-	function removeTokenRWalk(uint256 tokenId) external {
-		require(isTokenStakedRWalk(tokenId),"Token is not in the list.");
-		uint256 index = tokenIndicesRWalk[tokenId];
-		uint256 lastTokenId = stakedTokensRWalk[stakedTokensRWalk.length - 1];
-		stakedTokensRWalk[index -1] = lastTokenId;
-		tokenIndicesRWalk[lastTokenId] = index;
-		delete tokenIndicesRWalk[tokenId];
-		stakedTokensRWalk.pop();
-		lastActionIdsRWalk[tokenId] = -1;
+	function removeToken(uint256 tokenId) external {
+		require(isTokenStaked(tokenId), "Token is not in the list.");
+		uint256 index = tokenIndices[tokenId];
+		uint256 lastTokenId = stakedTokens[stakedTokens.length - 1];
+		stakedTokens[index - 1] = lastTokenId;
+		tokenIndices[lastTokenId] = index;
+		delete tokenIndices[tokenId];
+		stakedTokens.pop();
+		lastActionIds[tokenId] = -1;
 	}
 }

--- a/src/Deploy.js
+++ b/src/Deploy.js
@@ -1,7 +1,30 @@
-const basicDeployment = async function (deployerAcct, randomWalkAddr, activationTime, charityAddr, transferOwnership,switchToRuntime = true) {
-	return await basicDeploymentAdvanced("CosmicGame",deployerAcct, randomWalkAddr, activationTime, charityAddr, transferOwnership,switchToRuntime);
+const basicDeployment = async function (
+	deployerAcct,
+	randomWalkAddr,
+	activationTime,
+	charityAddr,
+	transferOwnership,
+	switchToRuntime = true,
+) {
+	return await basicDeploymentAdvanced(
+		"CosmicGame",
+		deployerAcct,
+		randomWalkAddr,
+		activationTime,
+		charityAddr,
+		transferOwnership,
+		switchToRuntime,
+	);
 };
-const basicDeploymentAdvanced = async function (cgName, deployerAcct, randomWalkAddr, activationTime, charityAddr, transferOwnership,switchToRuntime) {
+const basicDeploymentAdvanced = async function (
+	cgName,
+	deployerAcct,
+	randomWalkAddr,
+	activationTime,
+	charityAddr,
+	transferOwnership,
+	switchToRuntime,
+) {
 	let cosmicGame, cosmicToken, cosmicSignature, charityWallet, cosmicDAO, randomWalkNFT, raffleWallet;
 	if (switchToRuntime === undefined) {
 		console.error("switchToRuntime is not set");
@@ -54,14 +77,20 @@ const basicDeploymentAdvanced = async function (cgName, deployerAcct, randomWalk
 		randomWalkNFT = await ethers.getContractAt("RandomWalkNFT", randomWalkAddr);
 	}
 
-	const StakingWallet = await hre.ethers.getContractFactory("StakingWallet");
-	stakingWallet = await StakingWallet.connect(deployerAcct).deploy(
+	const StakingWalletCST = await hre.ethers.getContractFactory("StakingWalletCST");
+	stakingWalletCST = await StakingWalletCST.connect(deployerAcct).deploy(
 		cosmicSignature.address,
-		randomWalkAddr,
 		cosmicGame.address,
 		charityAddr,
 	);
-	await stakingWallet.deployed();
+	await stakingWalletCST.deployed();
+
+	const StakingWalletRWalk = await hre.ethers.getContractFactory("StakingWalletRWalk");
+	stakingWalletRWalk = await StakingWalletRWalk.connect(deployerAcct).deploy(
+		randomWalkAddr,
+		cosmicGame.address,
+	);
+	await stakingWalletRWalk.deployed();
 
 	const BusinessLogic = await ethers.getContractFactory("BusinessLogic");
 	bLogic = await BusinessLogic.connect(deployerAcct).deploy();
@@ -73,7 +102,8 @@ const basicDeploymentAdvanced = async function (cgName, deployerAcct, randomWalk
 	await cosmicGame.connect(deployerAcct).setBusinessLogicContract(bLogic.address);
 	await cosmicGame.connect(deployerAcct).setRandomWalk(randomWalkNFT.address);
 	await cosmicGame.connect(deployerAcct).setRaffleWallet(raffleWallet.address);
-	await cosmicGame.connect(deployerAcct).setStakingWallet(stakingWallet.address);
+	await cosmicGame.connect(deployerAcct).setStakingWalletCST(stakingWalletCST.address);
+	await cosmicGame.connect(deployerAcct).setStakingWalletRWalk(stakingWalletRWalk.address);
 	await cosmicGame.connect(deployerAcct).setMarketingWallet(marketingWallet.address);
 	await cosmicGame.connect(deployerAcct).setActivationTime(activationTime);
 	if (switchToRuntime) {
@@ -88,9 +118,10 @@ const basicDeploymentAdvanced = async function (cgName, deployerAcct, randomWalk
 		cosmicDAO,
 		raffleWallet,
 		randomWalkNFT,
-		stakingWallet,
+		stakingWalletCST,
+		stakingWalletRWalk,
 		marketingWallet,
 		bLogic,
 	};
 };
-module.exports = { basicDeployment,basicDeploymentAdvanced };
+module.exports = { basicDeployment, basicDeploymentAdvanced };

--- a/tasks/cosmic-tasks.js
+++ b/tasks/cosmic-tasks.js
@@ -1,6 +1,6 @@
 const { basicDeployment } = require("../src/Deploy.js");
 const fs = require("fs");
-task("deploy-local", "Deploys contracts to local network", async (args, hre) => {
+task("deploy-cosmicgame", "Deploys contracts to a  network", async (args, hre) => {
 	let configFile = args.deployconfig;
 	if (typeof configFile === "undefined" || configFile.length == 0) {
 		console.log("Please provide config file : --deployconfig [file_path]");
@@ -25,7 +25,8 @@ task("deploy-local", "Deploys contracts to local network", async (args, hre) => 
 		cosmicDAO,
 		raffleWallet,
 		randomWalkNFT,
-		stakingWallet,
+		stakingWalletCST,
+		stakingWalletRWalk,
 		marketingWallet,
 		bLogic,
 	} = await basicDeployment(
@@ -36,6 +37,13 @@ task("deploy-local", "Deploys contracts to local network", async (args, hre) => 
 		config_params.transferOwnership,
 		config_params.switchToRuntime,
 	);
+	console.log("contracts deployed");
+	if (config_params.donateToContract == true) {
+		let ethValue = "2";
+		let donationAmount = ethers.utils.parseEther(ethValue);
+		await cosmicGame.connect(deployerAcct).donate({value:donationAmount});
+		console.log("Donated "+ethValue+" ETH to contract");
+	}
 	console.log("CosmicGame address:", cosmicGame.address);
 	console.log("CosmicToken address:", cosmicToken.address);
 	console.log("CosmicSignature address:", cosmicSignature.address);
@@ -44,6 +52,9 @@ task("deploy-local", "Deploys contracts to local network", async (args, hre) => 
 	console.log("RaffleWallet address:", raffleWallet.address);
 	console.log("BidLogic address:", bLogic.address);
 	console.log("randomWalkNFT address:", randomWalkNFT.address);
+	console.log("StakingWalletCST address:", stakingWalletCST.address);
+	console.log("StakingWalletRWalk address:", stakingWalletRWalk.address);
+	console.log("MarketingWallet address:", marketingWallet.address);
 	console.log(
 		"INSERT INTO cg_contracts VALUES('" +
 			cosmicGame.address +
@@ -60,79 +71,13 @@ task("deploy-local", "Deploys contracts to local network", async (args, hre) => 
 			"','" +
 			randomWalkNFT.address +
 			"','" +
-			stakingWallet.address +
+			stakingWalletCST.address +
+			"','" +
+			stakingWalletRWalk.address +
 			"','" +
 			marketingWallet.address +
 			"','" +
-			bLogic.address+
-			"')",
-	);
-}).addParam("deployconfig", "Config file (JSON)");
-task("deploy-arbitrum", "Deploys contracts Arbitrum network", async (args, hre) => {
-	// same script as for local, but without donate() step
-	let configFile = args.deployconfig;
-	if (typeof configFile === "undefined" || configFile.length == 0) {
-		console.log("Please provide config file : --deployconfig [file_path]");
-		return;
-	}
-	const config_params_file = fs.readFileSync(configFile, "utf8");
-	let config_params;
-	try {
-		config_params = JSON.parse(config_params_file);
-		console.log(config_params);
-	} catch (err) {
-		console.error("Error while parsing JSON data:", err);
-		return;
-	}
-	console.log("Using file: " + configFile);
-	let deployerAcct = new hre.ethers.Wallet(config_params.privKey, hre.ethers.provider);
-	const {
-		cosmicGame,
-		cosmicToken,
-		cosmicSignature,
-		charityWallet,
-		cosmicDAO,
-		raffleWallet,
-		randomWalkNFT,
-		stakingWallet,
-		marketingWallet,
-		bLogic,
-	} = await basicDeployment(
-		deployerAcct,
-		config_params.randomWalkAddr,
-		config_params.activationTime,
-		config_params.charityAddr,
-		config_params.transferOwnership,
-		config_params.switchToRuntime,
-	);
-	console.log("CosmicGame address:", cosmicGame.address);
-	console.log("CosmicToken address:", cosmicToken.address);
-	console.log("CosmicSignature address:", cosmicSignature.address);
-	console.log("CharityWallet address:", charityWallet.address);
-	console.log("CosmicDAO address", cosmicDAO.address);
-	console.log("RaffleWallet address:", raffleWallet.address);
-	console.log("randomWalkNFT address:", randomWalkNFT.address);
-	console.log(
-		"INSERT INTO cg_contracts VALUES('" +
-			cosmicGame.address +
-			"','" +
-			cosmicSignature.address +
-			"','" +
-			cosmicToken.address +
-			"','" +
-			cosmicDAO.address +
-			"','" +
-			charityWallet.address +
-			"','" +
-			raffleWallet.address +
-			"','" +
-			randomWalkNFT.address +
-			"','" +
-			stakingWallet.address +
-			"','" +
-			marketingWallet.address +
-			"','" +
-			bLogic.address+
+			bLogic.address +
 			"')",
 	);
 }).addParam("deployconfig", "Config file (JSON)");


### PR DESCRIPTION
- Staking of RWalk was separated from staking of CST tokens
- The "num-winners" types of counters in BusinessLogic were renamed
- Deployment task (hardhat task) was simplified (and new field added (`donateToContract`))