### PR TITLE
Longest bidder accounting + bid statistics

### DIFF
--- a/contracts/BusinessLogic.sol
+++ b/contracts/BusinessLogic.sol
@@ -268,6 +268,7 @@ contract BusinessLogic is Context, Ownable {
 		// Initially this is 12 hours, but will grow slowly over time.
 		CSTAuctionLength = (12 * nanoSecondsExtra) / 1_000_000_000;
 		numRaffleParticipants[roundNum + 1] = 0;
+		_resetBidPrice();
 		bidPrice = address(this).balance / initialBidAmountFraction;
 		// note: we aren't resetting 'lastBidder' here because of reentrancy issues
 
@@ -279,6 +280,13 @@ contract BusinessLogic is Context, Ownable {
 		if (systemMode == CosmicGameConstants.MODE_PREPARE_MAINTENANCE) {
 			systemMode = CosmicGameConstants.MODE_MAINTENANCE;
 			emit SystemModeChanged(systemMode);
+		}
+	}
+	function _resetBidPrice() internal{
+		if (roundNum == 0) {
+			bidPrice = CosmicGameConstants.FIRST_ROUND_BID_PRICE;
+		} else {
+			bidPrice = address(this).balance / initialBidAmountFraction;
 		}
 	}
 	function _bidCommon(string memory message, CosmicGameConstants.BidType bidType) internal {
@@ -652,7 +660,7 @@ contract BusinessLogic is Context, Ownable {
 		require(msg.value > 0, CosmicGameErrors.NonZeroValueRequired("Donation amount must be greater than 0."));
 		if (block.timestamp < activationTime) {
 			// Set the initial bid prize only if the game has not started yet.
-			bidPrice = address(this).balance / initialBidAmountFraction;
+			_resetBidPrice();
 		}
 		emit DonationEvent(_msgSender(), msg.value);
 	}

--- a/contracts/Constants.sol
+++ b/contracts/Constants.sol
@@ -11,6 +11,7 @@ library CosmicGameConstants {
 	// You get 100 tokens when you bid
 	uint256 public constant TOKEN_REWARD = 100 * 1e18;
 	uint256 public constant LONGEST_BIDDER_TOKEN_REWARD = 1000 * 1e18;
+	uint256 public constant TOP_BIDDER_TOKEN_REWARD = 1000 * 1e18;
 	uint256 public constant MARKETING_REWARD = 15 * 1e18;
 	uint256 public constant DEFAULT_AUCTION_LENGTH = 12 * 3600;
 	uint256 public constant MODE_RUNTIME = 0;

--- a/contracts/Constants.sol
+++ b/contracts/Constants.sol
@@ -18,6 +18,12 @@ library CosmicGameConstants {
 	string public constant ERR_STR_MODE_MAINTENANCE = "System must be in MODE_MAINTENANCE";
 	string public constant ERR_STR_MODE_RUNTIME = "System in maintenance mode";
 
+	struct BidderStatRec {	// 192 bits in total, this layout fits single storage slot (256 bits)
+		uint64 bidPricePaidEth;	//fixed-point decimal, precision = 3 (ETH) digits, formula: bidPricePaidEth = bidPrice >> 15; (price in Wei units)
+		uint64 bidPricePaidCST; //fixed-point decimal, precision = 3 (ETH) digits, formula: bidPricePaidCST = bidPriceCST >> 15; (price in Wei units)
+		uint32 bidCount;
+		uint32 bidTime;        // duration of each bid, summarized
+	}
 	struct DonatedNFT {
 		IERC721 nftAddress;
 		uint256 tokenId;

--- a/contracts/Constants.sol
+++ b/contracts/Constants.sol
@@ -9,6 +9,7 @@ library CosmicGameConstants {
 
 	// You get 100 tokens when you bid
 	uint256 public constant TOKEN_REWARD = 100 * 1e18;
+	uint256 public constant LONGEST_BIDDER_TOKEN_REWARD = 1000 * 1e18;
 	uint256 public constant MARKETING_REWARD = 15 * 1e18;
 	uint256 public constant DEFAULT_AUCTION_LENGTH = 12 * 3600;
 	uint256 public constant MODE_RUNTIME = 0;

--- a/contracts/Constants.sol
+++ b/contracts/Constants.sol
@@ -6,6 +6,7 @@ import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 library CosmicGameConstants {
 	uint256 public constant MILLION = 10 ** 6;
 	uint256 public constant MAX_MESSAGE_LENGTH = 280;
+	uint256 public constant FIRST_ROUND_BID_PRICE = 1e14; // 1 / 10,000 of ETH
 
 	// You get 100 tokens when you bid
 	uint256 public constant TOKEN_REWARD = 100 * 1e18;

--- a/contracts/CosmicGame.sol
+++ b/contracts/CosmicGame.sol
@@ -82,6 +82,8 @@ contract CosmicGame is Ownable, IERC721Receiver {
 	address public longestBidderAddress = address(0);
 	uint256 public prevBidderStartTime = 0;
 	address public prevBidderAddress = address(0);
+	uint256 public topBidderNumBids = 0;
+	address public topBidderAddress = address(0);
 	// END OF Bidding and prize variables
 
 	// Percentages for fund distribution
@@ -118,7 +120,9 @@ contract CosmicGame is Ownable, IERC721Receiver {
 	// amount of CST tokens given as reward for every bid
 	uint256 public tokenReward = CosmicGameConstants.TOKEN_REWARD;
 	// amount of CST tokens given to the longest bidder
-	uint256 public longestBidderTokenReward = CosmicGameConstants.TOKEN_REWARD;
+	uint256 public longestBidderTokenReward = CosmicGameConstants.LONGEST_BIDDER_TOKEN_REWARD;
+	// amount of CST tokens given to the top bidder (maximum number of bids)
+	uint256 public topBidderTokenReward = CosmicGameConstants.TOP_BIDDER_TOKEN_REWARD;
 	// amount of CST tokens given as reward on every bid for marketing the project
 	uint256 public marketingReward = CosmicGameConstants.MARKETING_REWARD;
 	// maximum length of message attached to bid() operation
@@ -159,6 +163,18 @@ contract CosmicGame is Ownable, IERC721Receiver {
 		uint256 winnerIndex,
 		bool isStaker,
 		bool isRWalk
+	);
+	event EnduranceNFTWinnerEvent(
+		address indexed winner,
+		uint256 indexed round,
+		uint256 indexed tokenId,
+		uint256 winnerIndex
+	);
+	event TopBidderNFTWinnerEvent(
+		address indexed winner,
+		uint256 indexed round,
+		uint256 indexed tokenId,
+		uint256 winnerIndex
 	);
 	event DonatedNFTClaimedEvent(
 		uint256 indexed round,
@@ -202,6 +218,7 @@ contract CosmicGame is Ownable, IERC721Receiver {
 	// Token rewards
 	event TokenRewardChanged(uint256 newReward);
 	event LongestBidderTokenRewardChanged(uint256 newReward);
+	event TopBidderTokenRewardChanged(uint256 newReward);
 	event MarketingRewardChanged(uint256 newReward);
 	// System
 	event ActivationTimeChanged(uint256 newActivationTime);
@@ -667,7 +684,16 @@ contract CosmicGame is Ownable, IERC721Receiver {
 			CosmicGameErrors.SystemMode(CosmicGameConstants.ERR_STR_MODE_MAINTENANCE, systemMode)
 		);
 		longestBidderTokenReward = newTokenReward;
-		emit TokenRewardChanged(longestBidderTokenReward);
+		emit LongestBidderTokenRewardChanged(longestBidderTokenReward);
+	}
+
+	function setTopBidderTokenReward(uint256 newTokenReward) external onlyOwner {
+		require(
+			systemMode == CosmicGameConstants.MODE_MAINTENANCE,
+			CosmicGameErrors.SystemMode(CosmicGameConstants.ERR_STR_MODE_MAINTENANCE, systemMode)
+		);
+		topBidderTokenReward = newTokenReward;
+		emit TopBidderTokenRewardChanged(topBidderTokenReward);
 	}
 
 	function setMarketingReward(uint256 newMarketingReward) external onlyOwner {

--- a/contracts/CosmicGame.sol
+++ b/contracts/CosmicGame.sol
@@ -76,6 +76,7 @@ contract CosmicGame is Ownable, IERC721Receiver {
 	uint256 public CSTAuctionLength = CosmicGameConstants.DEFAULT_AUCTION_LENGTH;
 	// stores default auction duration, and used to reset the duration at every round start
 	uint256 public RoundStartCSTAuctionLength = CosmicGameConstants.DEFAULT_AUCTION_LENGTH;
+	mapping(address => CosmicGameConstants.BidderStatRec) public bidStats; // bidderAddress => (bid stats record)
 	// variables used to keep track of the bidder with longest bid time (accumulated)
 	uint256 public longestBidderTime = 0;
 	address public longestBidderAddress = address(0);

--- a/contracts/CosmicGame.sol
+++ b/contracts/CosmicGame.sol
@@ -117,6 +117,8 @@ contract CosmicGame is Ownable, IERC721Receiver {
 	uint256 public activationTime = 1702512000; // December 13 2023 19:00 New York Time
 	// amount of CST tokens given as reward for every bid
 	uint256 public tokenReward = CosmicGameConstants.TOKEN_REWARD;
+	// amount of CST tokens given to the longest bidder
+	uint256 public longestBidderTokenReward = CosmicGameConstants.TOKEN_REWARD;
 	// amount of CST tokens given as reward on every bid for marketing the project
 	uint256 public marketingReward = CosmicGameConstants.MARKETING_REWARD;
 	// maximum length of message attached to bid() operation
@@ -199,6 +201,7 @@ contract CosmicGame is Ownable, IERC721Receiver {
 	event RoundStartCSTAuctionLengthChanged(uint256 newAuctionLength);
 	// Token rewards
 	event TokenRewardChanged(uint256 newReward);
+	event LongestBidderTokenRewardChanged(uint256 newReward);
 	event MarketingRewardChanged(uint256 newReward);
 	// System
 	event ActivationTimeChanged(uint256 newActivationTime);
@@ -656,6 +659,15 @@ contract CosmicGame is Ownable, IERC721Receiver {
 		);
 		tokenReward = newTokenReward;
 		emit TokenRewardChanged(tokenReward);
+	}
+
+	function setLongestBidderTokenReward(uint256 newTokenReward) external onlyOwner {
+		require(
+			systemMode == CosmicGameConstants.MODE_MAINTENANCE,
+			CosmicGameErrors.SystemMode(CosmicGameConstants.ERR_STR_MODE_MAINTENANCE, systemMode)
+		);
+		longestBidderTokenReward = newTokenReward;
+		emit TokenRewardChanged(longestBidderTokenReward);
 	}
 
 	function setMarketingReward(uint256 newMarketingReward) external onlyOwner {

--- a/test/BidTimeAccounting.js
+++ b/test/BidTimeAccounting.js
@@ -70,74 +70,27 @@ describe("Bid time accounting", function () {
 		var bidParams = { msg: "", rwalk: -1 };
 		let params = ethers.utils.defaultAbiCoder.encode([bidParamsEncoding], [bidParams]);
 		let bidPrice = await cosmicGame.getBidPrice();
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800000000]);
 		await cosmicGame.connect(addr1).bid(params, { value: bidPrice });	// bid1 (addr1)
-	
-		console.log("\nafter bid1");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
 
 		bidPrice = await cosmicGame.getBidPrice();
-		await ethers.provider.send("evm_increaseTime", [1000]);
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800001000]);
 		await cosmicGame.connect(addr2).bid(params, { value: bidPrice });	// bid2	(addr2)
 		
-		console.log("\nafter bid2");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
-
 		bidPrice = await cosmicGame.getBidPrice();
-		await ethers.provider.send("evm_increaseTime", [5000]);
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800006000]);
 		await cosmicGame.connect(addr1).bid(params, { value: bidPrice });	// bid3 (addr1)
 				
-		console.log("\nafter bid3");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
-
 		bidPrice = await cosmicGame.getBidPrice();
-		await ethers.provider.send("evm_increaseTime", [1000]);
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800007000]);
 		await cosmicGame.connect(addr2).bid(params, { value: bidPrice });	// bid4 (addr2)
 
-		console.log("\nafter bid4");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
-
 		bidPrice = await cosmicGame.getBidPrice();
-		await ethers.provider.send("evm_increaseTime", [1000]);
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800008000]);
 		await cosmicGame.connect(addr1).bid(params, { value: bidPrice });	// bid5 (addr1)
 		
-		console.log("\nafter bid5");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
-
+		maxbtime = await cosmicGame.longestBidderTime();
+		maxbaddr = await cosmicGame.longestBidderAddress();
 		expect(maxbtime).to.equal(6000);
 		expect(maxbaddr).to.equal(addr2.address);
 	});
@@ -154,192 +107,65 @@ describe("Bid time accounting", function () {
 		// 		addr2 makes 6 bids
 		// 		addr3 makes 3 bids
 		// 		bid amount is 1000 for every bid
-		console.log("addr1 = "+addr1.address);console.log("addr2 = "+addr2.address);console.log("addr3 = "+addr3.address);
 		let maxbtime,maxbaddr,prevbst,prevbaddr;
 		let donationAmount = ethers.utils.parseEther("10");
 		await cosmicGame.donate({ value: donationAmount });
 		var bidParams = { msg: "", rwalk: -1 };
 		let params = ethers.utils.defaultAbiCoder.encode([bidParamsEncoding], [bidParams]);
 		let bidPrice = await cosmicGame.getBidPrice();
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800000000]);
 		await cosmicGame.connect(addr1).bid(params, { value: bidPrice });	// bid1 (addr1)
-	
-		console.log("\nafter bid1");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
 
 		bidPrice = await cosmicGame.getBidPrice();
-		await ethers.provider.send("evm_increaseTime", [1000]);
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800001000]);
 		await cosmicGame.connect(addr2).bid(params, { value: bidPrice });	// bid2	(addr2)
 		
-		console.log("\nafter bid2");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
-
 		bidPrice = await cosmicGame.getBidPrice();
-		await ethers.provider.send("evm_increaseTime", [1000]);
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800002000]);
 		await cosmicGame.connect(addr3).bid(params, { value: bidPrice });	// bid3 (addr3)
 				
-		console.log("\nafter bid3");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
-
 		bidPrice = await cosmicGame.getBidPrice();
-		await ethers.provider.send("evm_increaseTime", [1000]);
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800003000]);
 		await cosmicGame.connect(addr2).bid(params, { value: bidPrice });	// bid4 (addr2)
 
-		console.log("\nafter bid4");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
-
 		bidPrice = await cosmicGame.getBidPrice();
-		await ethers.provider.send("evm_increaseTime", [1000]);
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800004000]);
 		await cosmicGame.connect(addr1).bid(params, { value: bidPrice });	// bid5 (addr1)
 		
-		console.log("\nafter bid5");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
-
 		bidPrice = await cosmicGame.getBidPrice();
-		await ethers.provider.send("evm_increaseTime", [1000]);
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800005000]);
 		await cosmicGame.connect(addr2).bid(params, { value: bidPrice });	// bid6 (addr2)
 		
-		console.log("\nafter bid6");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
-
 		bidPrice = await cosmicGame.getBidPrice();
-		await ethers.provider.send("evm_increaseTime", [1000]);
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800006000]);
 		await cosmicGame.connect(addr3).bid(params, { value: bidPrice });	// bid7 (addr3)
 		
-		console.log("\nafter bid7");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
-
 		bidPrice = await cosmicGame.getBidPrice();
-		await ethers.provider.send("evm_increaseTime", [1000]);
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800007000]);
 		await cosmicGame.connect(addr2).bid(params, { value: bidPrice });	// bid8 (addr2)
 		
-		console.log("\nafter bid7");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
-
 		bidPrice = await cosmicGame.getBidPrice();
-		await ethers.provider.send("evm_increaseTime", [1000]);
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800008000]);
 		await cosmicGame.connect(addr1).bid(params, { value: bidPrice });	// bid9 (addr1)
 		
-		console.log("\nafter bid9");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
-
 		bidPrice = await cosmicGame.getBidPrice();
-		await ethers.provider.send("evm_increaseTime", [1000]);
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800009000]);
 		await cosmicGame.connect(addr2).bid(params, { value: bidPrice });	// bid10 (addr2)
 		
-		console.log("\nafter bid10");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
-
 		bidPrice = await cosmicGame.getBidPrice();
-		await ethers.provider.send("evm_increaseTime", [1000]);
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800010000]);
 		await cosmicGame.connect(addr1).bid(params, { value: bidPrice });	// bid11 (addr3)
 		
-		console.log("\nafter bid11");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
-
 		bidPrice = await cosmicGame.getBidPrice();
-		await ethers.provider.send("evm_increaseTime", [1000]);
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800011000]);
 		await cosmicGame.connect(addr2).bid(params, { value: bidPrice });	// bid12(addr2)
 		
-		console.log("\nafter bid12");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
-
 		bidPrice = await cosmicGame.getBidPrice();
-		await ethers.provider.send("evm_increaseTime", [1000]);
+		await ethers.provider.send("evm_setNextBlockTimestamp", [1800012000]);
 		await cosmicGame.connect(addr1).bid(params, { value: bidPrice });	// bid13 (addr1)
 		
-		console.log("\nafter bid13");
-		maxbtime = await cosmicGame.maxBidderTime();
-		console.log("max bidder time:");console.log(maxbtime);
-		maxbaddr = await cosmicGame.maxBidderAddress();
-		console.log("max bidder addr:");console.log(maxbaddr);
-		prevbaddr = await cosmicGame.prevBidderAddress();
-		console.log("previous bidder addr:");console.log(prevbaddr);
-		prevbst = await cosmicGame.prevBidderStartTime();
-		console.log("prevous bidder start time:");console.log(prevbst);
+		maxbtime = await cosmicGame.longestBidderTime();
+		maxbaddr = await cosmicGame.longestBidderAddress();
 
 		expect(maxbtime).to.equal(6000);
 		expect(maxbaddr).to.equal(addr2.address);

--- a/test/Cosmic.js
+++ b/test/Cosmic.js
@@ -556,6 +556,9 @@ describe("Cosmic Set1", function () {
 		await cosmicGame.connect(owner).setTokenReward(ethers.BigNumber.from("1234567890"));
 		expect(await cosmicGame.tokenReward()).to.equal(ethers.BigNumber.from("1234567890"));
 
+		await cosmicGame.connect(owner).setLongestBidderTokenReward(ethers.BigNumber.from("1234567890"));
+		expect(await cosmicGame.longestBidderTokenReward()).to.equal(ethers.BigNumber.from("1234567890"));
+
 		await cosmicGame.connect(owner).setMarketingReward(ethers.BigNumber.from("1234567890"));
 		expect(await cosmicGame.marketingReward()).to.equal(ethers.BigNumber.from("1234567890"));
 

--- a/test/Cosmic.js
+++ b/test/Cosmic.js
@@ -559,6 +559,9 @@ describe("Cosmic Set1", function () {
 		await cosmicGame.connect(owner).setLongestBidderTokenReward(ethers.BigNumber.from("1234567890"));
 		expect(await cosmicGame.longestBidderTokenReward()).to.equal(ethers.BigNumber.from("1234567890"));
 
+		await cosmicGame.connect(owner).setTopBidderTokenReward(ethers.BigNumber.from("1234567890"));
+		expect(await cosmicGame.topBidderTokenReward()).to.equal(ethers.BigNumber.from("1234567890"));
+
 		await cosmicGame.connect(owner).setMarketingReward(ethers.BigNumber.from("1234567890"));
 		expect(await cosmicGame.marketingReward()).to.equal(ethers.BigNumber.from("1234567890"));
 


### PR DESCRIPTION
Longest bidder feature completed
Accounting per bidder (ETH paid, CST paid,bid count, bid time)
--- update --
more commits added:
- Endurance Champion Prize
- Set bidPrice to 0.00001 on round 0
- Top bidder reward (highest number of bids)
--- update 2 --
- Reorganized statistics code into internal functions (removed redundancy)