### PR TITLE
Update to solidity & test directory

### DIFF
--- a/contracts/BusinessLogic.sol
+++ b/contracts/BusinessLogic.sol
@@ -452,8 +452,10 @@ contract BusinessLogic is Context, Ownable {
 			emit EnduranceChampionWinnerEvent(enduranceChampion, roundNum, tokenId, erc20TokenReward, winnerIndex);
 			winnerIndex += 1;
 		}
-		{
-			// Stellar Spender Prize
+
+		if (stellarSpender != address(0)) {
+			// Stellar Spender Prize. We need to check for address(0) because all the bids of the round can be made with CST,
+			// in that case, no one will get the prize
 			(, bytes memory data) = address(nft).call(
 				abi.encodeWithSelector(CosmicSignature.mint.selector, stellarSpender, roundNum)
 			);

--- a/contracts/BusinessLogic.sol
+++ b/contracts/BusinessLogic.sol
@@ -405,11 +405,11 @@ contract BusinessLogic is Context, Ownable {
 				)
 			);
 		}
+		_updateEnduranceChampion();
 
 		address winner = lastBidder;
 		// This prevents reentracy attack. todo: think about this more and make a better comment
 		lastBidder = address(0);
-		_updateEnduranceChampion();
 
 		winners[roundNum] = winner;
 

--- a/contracts/BusinessLogic.sol
+++ b/contracts/BusinessLogic.sol
@@ -386,6 +386,7 @@ contract BusinessLogic is Context, Ownable {
 			CosmicGameErrors.EarlyClaim("Not enough time has elapsed.", prizeTime, block.timestamp)
 		);
 		require(lastBidder != address(0), CosmicGameErrors.NoLastBidder("There is no last bidder."));
+		address winner;
 		if (block.timestamp - prizeTime < timeoutClaimPrize) {
 			// The winner has [timeoutClaimPrize] to claim the prize.
 			// After the this interval have elapsed, then *anyone* is able to claim the prize!
@@ -404,10 +405,12 @@ contract BusinessLogic is Context, Ownable {
 					timeToWait
 				)
 			);
+			winner = lastBidder;
+		} else {
+			winner = _msgSender();
 		}
 		_updateEnduranceChampion();
 
-		address winner = lastBidder;
 		// This prevents reentracy attack. todo: think about this more and make a better comment
 		lastBidder = address(0);
 

--- a/contracts/StakingWalletCST.sol
+++ b/contracts/StakingWalletCST.sol
@@ -286,4 +286,32 @@ contract StakingWalletCST is Ownable {
 		stakedTokens.pop();
 		lastActionIds[tokenId] = -1;
 	}
+	function unstakeClaim(uint256 stakeActionId, uint256 ETHDepositId) public {
+		// executes 2 actions in a single pass
+		//      1:      unstakes token using action [stakeActionId]
+		//      2:      claims reward corresponding to the deposit [ETHDepositId]
+		unstake(stakeActionId);
+		claimReward(stakeActionId, ETHDepositId);
+	} 
+	function unstakeClaimMany(
+		uint256[] memory unstake_actions,
+		uint256[] memory claim_actions,
+		uint256[] memory claim_deposits
+	) external {
+		for (uint256 i = 0; i < unstake_actions.length; i++) {
+			unstake(unstake_actions[i]);
+		}
+		require(
+			claim_actions.length == claim_deposits.length,
+			CosmicGameErrors.IncorrectArrayArguments(
+				"Claim array arguments must be of the same length.",
+				claim_actions.length,
+				claim_deposits.length
+			)
+		);
+		for (uint256 i = 0; i < claim_actions.length; i++) {
+			claimReward(claim_actions[i], claim_deposits[i]);
+		}
+	} 
+
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -11,6 +11,7 @@ module.exports = {
 		version: "0.8.26",
 
 		settings: {
+			evmVersion: "cancun",
 			// // [Comment-202408026]
 			// // By default, this is "paris".
 			// // See https://hardhat.org/hardhat-runner/docs/config

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
 	"name": "Cosmic-Signature",
 	"devDependencies": {
 		"@nomicfoundation/hardhat-toolbox": "^2.0.2",
-		"hardhat": "^2.20.1",
+		"hardhat": "^2.22.7",
 		"hardhat-docgen": "^1.3.0",
 		"hardhat-abi-exporter": "^2.10.1",
 		"@nomiclabs/hardhat-etherscan": "^3.1.8",
-		"hardhat-tracer": "^2.8.2",
+		"hardhat-tracer": "^3.0.0",
 		"@openzeppelin/contracts": "^4.9.6",
-		"@openzeppelin/hardhat-upgrades": "^1.28.0"
+		"@openzeppelin/hardhat-upgrades": "^1.28.0",
+		"solidity-coverage": "^0.8.12"
 	},
 	"dependencies": {
 	}

--- a/test/Events.js
+++ b/test/Events.js
@@ -96,9 +96,10 @@ describe("Events", function () {
 		await cosmicGame.connect(owner).donate({ value: INITIAL_AMOUNT });
 		const donationAmount = ethers.utils.parseEther("1");
 
+		let roundNum = 0;
 		await expect(cosmicGame.connect(donor).donate({ value: donationAmount }))
 			.to.emit(cosmicGame, "DonationEvent")
-			.withArgs(donor.address, donationAmount);
+			.withArgs(donor.address, donationAmount, roundNum);
 
 		const contractBalance = await ethers.provider.getBalance(cosmicGame.address);
 		expect(contractBalance).to.equal(donationAmount.add(INITIAL_AMOUNT));


### PR DESCRIPTION
- Bugfix to prevent EdnduranceChampion becomes address(0) if only 1 bid is made for the entire round
- Bugfix to send the main prize to correct winner if lastBidder fails to claim it in 24 hours
- Fixes to test directory
- Added missing function (from previous version) for advanced unstake & claim operation in a single TX
- Check for address(0) in StellarSpender prize
- Upgrade to hardhat 2.22 + evm target = cancun